### PR TITLE
Un-pin the ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 .bundle/
 history.yml
 *DS_STORE

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.1.5'
 
 gem 'dashing'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,5 @@ DEPENDENCIES
   twitter (>= 5.9.0)
   xml-simple (~> 1.1.4)
 
-RUBY VERSION
-   ruby 2.3.3p222
-
 BUNDLED WITH
-   1.13.7
+   1.16.0.pre.2


### PR DESCRIPTION
This may be required later for Flynn deployments, but that's a :skull: project at the moment anyway.