### PR TITLE
Add ENBW menu widget

### DIFF
--- a/jobs/enbw.rb
+++ b/jobs/enbw.rb
@@ -1,0 +1,17 @@
+require 'net/https'
+require 'json'
+require 'pp'
+
+SCHEDULER.every '5m', first_in: 0 do
+  http = Net::HTTP.new('enbw.herokuapp.com', 443)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  request = Net::HTTP::Get.new("/")
+  request["Accept"] = "application/json"
+  response = http.request(request)
+  beers = JSON.parse(response.body)["beers"]
+  send_event(
+    'enbw',
+    beers: beers
+  )
+end

--- a/widgets/enbw/enbw.coffee
+++ b/widgets/enbw/enbw.coffee
@@ -1,0 +1,9 @@
+class Dashing.Enbw extends Dashing.Widget
+
+  ready: ->
+    # This is fired when the widget is done being rendered
+
+  onData: (data) ->
+    # Handle incoming data
+    # You can access the html node of this widget with `@node`
+    # Example: $(@node).fadeOut().fadeIn() will make the node flash each time data comes in.

--- a/widgets/enbw/enbw.html
+++ b/widgets/enbw/enbw.html
@@ -1,0 +1,12 @@
+<h1 class="title" data-bind="title"></h1>
+
+<table>
+  <tbody>
+    <tr data-foreach-beer="beers">
+      <td><span data-bind="beer.name | raw"></span></td>
+      <td><span data-bind="beer.abv | append '%'"></span></td>
+    </tr>
+  </tbody>
+</table>
+
+<p class="updated-at" data-bind="updatedAtMessage"></p>

--- a/widgets/enbw/enbw.scss
+++ b/widgets/enbw/enbw.scss
@@ -1,0 +1,36 @@
+// ----------------------------------------------------------------------------
+// Sass declarations
+// ----------------------------------------------------------------------------
+//$background-color:  #EC3C6B;
+$background-color:  #7EBBE4;
+
+$full-color:  rgba(255, 255, 255, 1);
+$light-color: rgba(255, 255, 255, 0.7);
+
+// ----------------------------------------------------------------------------
+// Widget-forecast styles
+// ----------------------------------------------------------------------------
+.widget-enbw {
+
+  background-color: $background-color;
+
+  .title {
+    color: $light-color;
+  }
+
+  .temp {
+    color: $full-color;
+  }
+
+  .summary {
+    color: $light-color;
+  }
+
+  .more-info {
+      color: $light-color;
+  }
+
+  .updated-at {
+    color: rgba(0, 0, 0, 0.3);
+  }
+}

--- a/widgets/enbw/enbw.scss
+++ b/widgets/enbw/enbw.scss
@@ -13,6 +13,7 @@ $light-color: rgba(255, 255, 255, 0.7);
 .widget-enbw {
 
   background-color: $background-color;
+  font-size: .7em;
 
   .title {
     color: $light-color;


### PR DESCRIPTION
![image 2017-10-12 at 4 22 39 pm](https://user-images.githubusercontent.com/57629/31519921-b0695ea8-af69-11e7-909b-2546ff2cff48.png)

I haven't added this to any dashboard layouts yet. Open to suggestions on where it goes. You can add it in for local testing with:

```
    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
      <div data-id="enbw" data-view="Enbw" data-title="On Tap at ENBW" ></div>
    </li>
```